### PR TITLE
Support GHC 8.6.* by utilizing ghc-heap instead of ghc-heap-view

### DIFF
--- a/ghc-datasize.cabal
+++ b/ghc-datasize.cabal
@@ -15,14 +15,15 @@ description:        ghc-datasize is a tool to determine the size of data
                     recursive data structures is supported. All sizes are in
                     Bytes.
 
-tested-with: GHC == 7.6.3, GHC == 7.8.4, GHC == 7.10.3, GHC == 8.0.1
+tested-with: GHC == 8.6.5
 
 Library
   Exposed-modules: GHC.DataSize
   Default-Language: Haskell2010
-  Build-depends: base == 4.*,
+  Build-depends: base >= 4.12 && < 4.13,
                  deepseq >= 1.3 && < 1.5,
-                 ghc-heap-view >= 0.6
+                 ghc-heap == 8.6.*,
+                 ghc-prim == 0.5.3
   Hs-source-dirs: src/
   Ghc-options: -Wall
 

--- a/ghc-datasize.cabal
+++ b/ghc-datasize.cabal
@@ -8,7 +8,7 @@ build-type:         Simple
 author:             Dennis Felsing <dennis@felsin9.de>
 maintainer:         Dennis Felsing <dennis@felsin9.de>
 homepage:           http://felsin9.de/nnis/ghc-datasize
-copyright:          Dennis Felsing 2012
+copyright:          Dennis Felsing 2012-2019
 synopsis:           Determine the size of data structures in GHC's memory
 description:        ghc-datasize is a tool to determine the size of data
                     structures in GHC's memory. Determining the size of

--- a/src/GHC/DataSize.hs
+++ b/src/GHC/DataSize.hs
@@ -27,11 +27,6 @@ import Control.Monad
 
 import System.Mem
 
---import qualified Data.IntMap as IntMap
-
---depth :: Int
---depth = 10^10
-
 -- Inspired by Simon Marlow:
 -- https://ghcmutterings.wordpress.com/2009/02/12/53/
 

--- a/src/GHC/DataSize.hs
+++ b/src/GHC/DataSize.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE UnboxedTuples #-}
+
 {- |
    Module      : GHC.DataSize
    Copyright   : (c) Dennis Felsing
@@ -15,20 +17,15 @@ module GHC.DataSize (
 
 import Control.DeepSeq (NFData, force)
 
-#if __GLASGOW_HASKELL < 708
 import Data.Word (Word)
-#endif
 
-import GHC.HeapView hiding (size)
+import GHC.Exts
+import GHC.Exts.Heap hiding (size)
+import GHC.Exts.Heap.Constants (wORD_SIZE)
 
 import Control.Monad
 
 import System.Mem
-
--- This used to be available via GHC.Constants
-#include "MachDeps.h"
-wORD_SIZE :: Int
-wORD_SIZE = SIZEOF_HSWORD
 
 --import qualified Data.IntMap as IntMap
 
@@ -42,8 +39,8 @@ wORD_SIZE = SIZEOF_HSWORD
 --   evaluated yet and only the size of the initial closure is returned.
 closureSize :: a -> IO Word
 closureSize x = do
-  (_,y,_) <- getClosureRaw x
-  return . fromIntegral $ length y * wORD_SIZE
+  rawWds <- getClosureRawWords x
+  return . fromIntegral $ length rawWds * wORD_SIZE
 
 -- | Calculate the recursive size of GHC objects in Bytes. Note that the actual
 --   size in memory is calculated, so shared values are only counted once.
@@ -89,3 +86,16 @@ recursiveSize x = do
 
 recursiveSizeNF :: NFData a => a -> IO Word
 recursiveSizeNF = recursiveSize . force
+
+-- | Adapted from 'GHC.Exts.Heap.getClosureRaw' which isn't exported.
+--
+-- This returns the raw words of the closure on the heap. Once back in the
+-- Haskell world, the raw words that hold pointers may be outdated after a
+-- garbage collector run.
+getClosureRawWords :: a -> IO [Word]
+getClosureRawWords x = do
+    case unpackClosure# x of
+        (# _iptr, dat, _pointers #) -> do
+            let nelems = (I# (sizeofByteArray# dat)) `div` wORD_SIZE
+                end = fromIntegral nelems - 1
+            pure [W# (indexWordArray# dat i) | I# i <- [0.. end] ]


### PR DESCRIPTION
These days, `ghc-heap-view` from versions 0.6.0 onward is basically a `ghc-heap` wrapper with a few extra utilities (which this package doesn't even utilize). For continued compatibility with new GHC versions and to avoid unnecessary dependencies, it seems to make sense that we instead depend directly on `ghc-heap`.

This version only works for GHC 8.6.*. Those on older GHC versions can utilize older versions of this library.